### PR TITLE
Fixes generate_to_file using unicode characters

### DIFF
--- a/textgenrnn/textgenrnn.py
+++ b/textgenrnn/textgenrnn.py
@@ -340,7 +340,7 @@ class textgenrnn:
 
     def generate_to_file(self, destination_path, **kwargs):
         texts = self.generate(return_as_list=True, **kwargs)
-        with open(destination_path, 'w') as f:
+        with open(destination_path, 'w', encoding="utf-8") as f:
             for text in texts:
                 f.write("{}\n".format(text))
 


### PR DESCRIPTION
Fixes generate_to_file using unicode characters by adding encoding="utf-8" in the open command.